### PR TITLE
Fix install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={'': 'src'},
     python_requires='>=3.6',
     install_requires=[
-        "schnetpack>=0.3.0"
+        "schnetpack>=0.3.0",
         "torch>=0.4.1",
         "numpy",
         "ase>=3.16",


### PR DESCRIPTION
The missing comma leads to "InvalidVersionSpec" error when trying to export the conda environment.